### PR TITLE
Remove references to 'direct' wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ var blue = [
 //Report all crossings
 console.log('crossings=', boxIntersect(red, blue))
 
-//Again can use a visitor.  Also possible to use lower overhead direct wrapper.
-boxIntersect.direct(red, blue, function(r, b) {
+//Again can use a visitor:
+boxIntersect(red, blue, function(r, b) {
   console.log('overlap:', red[r], blue[b])
 })
 ```

--- a/example/bipartite.js
+++ b/example/bipartite.js
@@ -16,7 +16,7 @@ var blue = [
 //Report all crossings
 console.log('crossings=', boxIntersect(red, blue))
 
-//Again can use a visitor.  Also possible to use lower overhead direct wrapper.
+//Again can use a visitor:
 boxIntersect(red, blue, function(r, b) {
   console.log('overlap:', red[r], blue[b])
 })


### PR DESCRIPTION
Cool library!

This PR removes `.direct()` from the README, as I gather it's a removed API.